### PR TITLE
Fix infinite loop when scaling small text

### DIFF
--- a/src/defaults/aspect-matching-wrapper.js
+++ b/src/defaults/aspect-matching-wrapper.js
@@ -1,8 +1,6 @@
 export default class AspectMatchingWrapper {
-  constructor(box, { rough = 100, precision = 1 } = {}) {
+  constructor(box) {
     this._box = box;
-    this._rough = rough;
-    this._precision = precision;
     box.wrap = true;
   }
 
@@ -12,23 +10,24 @@ export default class AspectMatchingWrapper {
     this._adjustWidthWhile({
       condition: () =>
         this._box.frame.width > width && this._box.outer.aspect > aspect,
-      step: -this._rough,
+      step: -width / 2,
     });
 
     this._adjustWidthWhile({
       condition: () => this._box.outer.aspect < aspect,
-      step: this._precision,
+      step: 1,
     });
-    
+
     const frameWidth = this._box.frame.width;
 
     this._box.width = frameWidth <= width ? width : frameWidth;
     this._box.height = frameWidth / aspect;
   }
 
-  _adjustWidthWhile({ condition, step = 1 }) {
+  _adjustWidthWhile({ condition, step }) {
     while (condition()) {
       this._box.width = this._box.frame.width + step;
+
       if (!this._box.widthHasOverflow) continue;
 
       this._box.width = this._box.content.width;


### PR DESCRIPTION
If text wrap element was already smaller than the `rough` value it would cause an infinite loop when trying to scale it.